### PR TITLE
Change "l" to "L" in "nexus-flux/adapters/local"

### DIFF
--- a/src/__tests__/Root.jsx
+++ b/src/__tests__/Root.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import LocalFlux from 'nexus-flux/adapters/local';
+import LocalFlux from 'nexus-flux/adapters/Local';
 import Nexus from '../';
 const { Lifespan, Remutable } = Nexus;
 


### PR DESCRIPTION
```
Message:
    Cannot find module 'nexus-flux/adapters/local'
Details:
    code: MODULE_NOT_FOUND
Stack:
Error: Cannot find module 'nexus-flux/adapters/local'
```