### PR TITLE
Feature multi nexus

### DIFF
--- a/src/bindComponent.jsx
+++ b/src/bindComponent.jsx
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import Promise from 'bluebird';
 
 import Nexus from './Nexus';
+import createBoundComponent from './createBoundComponent';
 
 const STATUS = {
   PREFETCH: 'PREFETCH',
@@ -140,11 +141,13 @@ function bindComponent(
         }
         return [STATUS.PENDING, defaultValue, defaultValue];
       });
+      this.BoundComponent = createBoundComponent(this, Component);
     }
 
     render() {
       Nexus.currentNexus = this.nexus;
-      return <Component {...this.getChildrenProps()} />;
+      const { BoundComponent } = this;
+      return <BoundComponent {...this.getChildrenProps()} />;
     }
   };
 }

--- a/src/bindRoot.jsx
+++ b/src/bindRoot.jsx
@@ -63,16 +63,6 @@ function bindRoot(
       }
     }
 
-    createComponent() {
-      const { nexus } = this;
-      this.Component = class extends Component {
-        render() {
-          Nexus.currentNexus = nexus;
-          return super.render();
-        }
-      };
-    }
-
     componentDidMount() {
       this.stopInjecting();
     }

--- a/src/bindRoot.jsx
+++ b/src/bindRoot.jsx
@@ -6,6 +6,7 @@ const __DEV__ = process.env.NODE_ENV === 'development';
 import _ from 'lodash';
 
 import Nexus from './Nexus';
+import createBoundComponent from './createBoundComponent';
 
 function bindRoot(
     Component,
@@ -62,6 +63,16 @@ function bindRoot(
       }
     }
 
+    createComponent() {
+      const { nexus } = this;
+      this.Component = class extends Component {
+        render() {
+          Nexus.currentNexus = nexus;
+          return super.render();
+        }
+      };
+    }
+
     componentDidMount() {
       this.stopInjecting();
     }
@@ -83,12 +94,14 @@ function bindRoot(
       else {
         Object.assign(this, createNexus.call(this, { data, ...otherProps })); // eslint-disable-line object-shorthand
       }
+      this.BoundComponent = createBoundComponent(this, Component);
       this.startInjecting(data);
     }
 
     render() {
       Nexus.currentNexus = this.nexus;
-      return <Component {...this.getOtherProps()} />;
+      const { BoundComponent } = this;
+      return <BoundComponent {...this.getOtherProps()} />;
     }
   };
 }

--- a/src/createBoundComponent.jsx
+++ b/src/createBoundComponent.jsx
@@ -1,0 +1,8 @@
+import Nexus from './Nexus';
+
+export default ({ nexus }, Component) => class extends Component {
+  render() {
+    Nexus.currentNexus = nexus;
+    return super.render();
+  }
+};


### PR DESCRIPTION
@bind and @root now decorate the render method of the wrapped component with an assignment of the Nexus.currentNexus global. This allows multiple roots of React Nexus living concurrently.