### PR TITLE
Add test for .prepare when Context is in root

### DIFF
--- a/src/__tests__/fixtures/components/RootComponentWithContextInside.jsx
+++ b/src/__tests__/fixtures/components/RootComponentWithContextInside.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { T, propType, schemas } from '../types';
+import CustomHTTPFlux from '../fluxes/CustomHTTPFlux';
+import { Context, inject, isPending, lastValueOf } from '../../../';
+
+@inject(({ http }) => ({
+  users: http.get('/users'),
+}))
+class UserList extends React.Component {
+  static displayName = 'UserList';
+  static propTypes = {
+    users: propType(T.Array({ type: schemas.user })),
+  }
+  render() {
+    const { users } = this.props;
+    return (
+      <div>
+        {isPending(users) ? 'loading...' : lastValueOf(users).map((user) => user.userName).join()}
+      </div>
+    );
+  }
+}
+
+class RootComponentWithContextInside extends React.Component {
+  static displayName = 'RootComponentWithContextInside';
+  constructor(...args) {
+    super(...args);
+    this.nexus = {
+      http: new CustomHTTPFlux('http://127.0.0.1:8888'),
+    };
+  }
+  render() {
+    return (
+      <Context {...this.nexus}>
+        <UserList />
+      </Context>
+    );
+  }
+}
+
+export default RootComponentWithContextInside;

--- a/src/__tests__/fixtures/components/User.jsx
+++ b/src/__tests__/fixtures/components/User.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import T from 'typecheck-decorator';
+import { T, propType, schemas } from '../types';
 
 import { inject, pure, isPending, lastErrorOf, lastValueOf, LocalFlux, HTTPFlux } from '../../../';
 
@@ -43,19 +43,6 @@ function FollowButton({ following, onClick }) {
   return <p>{following.value().toString()}</p>;
 }
 
-function propType(schema) {
-  return T.toPropType(T.Array(T.shape([
-    T.option(T.oneOf(T.exactly(null), T.Error())), // err
-    T.option(schema), // res
-  ])));
-}
-
-const userSchema = T.shape({
-  userId: T.String(),
-  userName: T.String(),
-  profilePicture: T.String(),
-});
-
 @inject(({ local }) => ({
   authToken: local.get('/authToken'),
   fontSize: local.get('/fontSize'),
@@ -76,10 +63,10 @@ export default class User extends React.Component {
     fontSize: propType(T.oneOf(T.String(), T.Number())),
     http: React.PropTypes.instanceOf(HTTPFlux),
     local: React.PropTypes.instanceOf(LocalFlux),
-    me: propType(userSchema),
-    user: propType(userSchema),
+    me: propType(schemas.user),
+    user: propType(schemas.user),
     userId: React.PropTypes.string.isRequired,
-    users: propType(T.Array({ type: userSchema })),
+    users: propType(T.Array({ type: schemas.user })),
   };
 
   constructor(props, context) {

--- a/src/__tests__/fixtures/types.jsx
+++ b/src/__tests__/fixtures/types.jsx
@@ -1,0 +1,18 @@
+import T from 'typecheck-decorator';
+
+function propType(schema) {
+  return T.toPropType(T.Array(T.shape([
+    T.option(T.oneOf(T.exactly(null), T.Error())), // err
+    T.option(schema), // res
+  ])));
+}
+
+const schemas = {
+  user: T.shape({
+    userId: T.String(),
+    userName: T.String(),
+    profilePicture: T.String(),
+  }),
+};
+
+export { T, propType, schemas };

--- a/src/__tests__/index.jsx
+++ b/src/__tests__/index.jsx
@@ -9,9 +9,11 @@ Promise.promisifyAll(fs);
 
 import app, { users, authTokens } from './fixtures/app';
 import User from './fixtures/components/User';
+import RootComponentWithContextInside from './fixtures/components/RootComponentWithContextInside';
 import CustomHTTPFlux from './fixtures/fluxes/CustomHTTPFlux';
 import CustomLocalFlux from './fixtures/fluxes/CustomLocalFlux';
 import Nexus from '../';
+import $nexus from '../$nexus';
 
 describe('Nexus', () => {
   let server;
@@ -72,6 +74,15 @@ describe('Nexus', () => {
       });
     })
     .catch((err) => done(err));
+  });
+  it('.prepare with Context in root component', () => {
+    const tree = <RootComponentWithContextInside />;
+    return Nexus.prepare(tree).then((nexus) => {
+      should(nexus).be.an.Object();
+      should(nexus[$nexus]).have.a.property('http').which.is.an.instanceOf(CustomHTTPFlux);
+      const markup = renderToStaticMarkup(tree);
+      should(markup).be.eql('<div>Immanuel Kant,Frierich Nietzsche,Plato</div>');
+    });
   });
   it('.local.dispatch', (done) => {
     const local = new CustomLocalFlux();


### PR DESCRIPTION
Currently, when the Context component is in the Root component's render function, the Nexus.prepare function does not work properly (bad nexus and rendered markup).

This commit add a test for this case.