### PR TITLE
Fix incompatibility with lodash 4

### DIFF
--- a/lib/HTTP/Store.js
+++ b/lib/HTTP/Store.js
@@ -33,8 +33,7 @@ class HTTPStore extends Store {
         if(!state.hasOwnProperty(path)) {
           this.delete(path);
         }
-      })
-    .commit();
+      });
     _.each(state, (dump, path) => this._set(path, Store.State.create(dump)));
     return this;
   }

--- a/lib/Memory/Store.js
+++ b/lib/Memory/Store.js
@@ -29,8 +29,7 @@ class MemoryStore extends Store {
         if(!state.hasOwnProperty(path)) {
           this.delete(path);
         }
-      })
-    .commit();
+      });
     _.each(state, (dump, path) => this.set(path, Store.State.create(dump)));
     return this;
   }


### PR DESCRIPTION
Since lodash 4 `forEach` implicitly ends chain sequences.
Removed `.commit` calls that was causing errors.

See https://github.com/lodash/lodash/wiki/Changelog#compatibility-warnings