### PR TITLE
[WG-603] Bug fixes client-side

### DIFF
--- a/lib/Flux.js
+++ b/lib/Flux.js
@@ -50,7 +50,7 @@ class StoreNotFoundError extends Error {
 function findInMatchers(needle, haystack) {
   return _(haystack)
     .map(([matcher, handler]) => [handler, matcher(needle)])
-  .find(([, query]) => query !== null);
+    .find(([, query]) => query !== null);
 }
 
 @creatable
@@ -130,6 +130,12 @@ class Flux {
     const [path] = binding;
     const [store, query] = this.matchStore(path);
     return await store.fetch(query);
+  }
+
+  observeStore(...binding) {
+    const [path, params, onChange] = binding;
+    const [store, query] = this.matchStore(path);
+    return store.observe(query, params, onChange);
   }
 
   readStoreFromState(...binding) {

--- a/lib/HTTP/Store.js
+++ b/lib/HTTP/Store.js
@@ -47,7 +47,7 @@ class HTTPStore extends Store {
   readFromState(queryOrPath) {
     const path = typeof queryOrPath === 'string' ? queryOrPath : this.toPath(queryOrPath);
     if(!this.data.has(path)) {
-      return Store.State.reject('Store not found', { path });
+      return Store.State.pending({ path });
     }
     return this.data.get(path).state;
   }
@@ -119,7 +119,7 @@ class HTTPStore extends Store {
     if(refreshHandle !== null) {
       clearInterval(refreshHandle);
     }
-    this.data.get(path).observers.remove(observer);
+    this.data.get(path).observers.delete(observer);
     return this;
   }
 }

--- a/lib/HTTP/headersToObject.js
+++ b/lib/HTTP/headersToObject.js
@@ -2,7 +2,7 @@ import entriesToObject from '../util/entriesToObject';
 
 function headersToObject(headers) {
   if(typeof headers.entries === 'function') {
-    return entriesToObject(headersToObject.entries());
+    return entriesToObject(headers.entries());
   }
   if(typeof headers.raw === 'function') {
     return headers.raw();

--- a/lib/Memory/Store.js
+++ b/lib/Memory/Store.js
@@ -43,7 +43,7 @@ class MemoryStore extends Store {
   readFromState(queryOrPath) {
     const path = typeof queryOrPath === 'string' ? queryOrPath : this.toPath(queryOrPath);
     if(!this.data.has(path)) {
-      return Store.State.reject('Store not found', { path });
+      return Store.State.pending({ path });
     }
     return this.data.get(path).state;
   }
@@ -68,7 +68,9 @@ class MemoryStore extends Store {
   _unobserve(path, observer) {
     const [, firstTick] = observer;
     clearImmediate(firstTick);
-    this.data.get(path).observers.remove(observer);
+    if(this.data.has(path)) {
+      this.data.get(path).observers.delete(observer);
+    }
     return this;
   }
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -18,8 +18,9 @@ function actions(getBindings, { displayName = void 0, fluxKey = defaultFluxKey }
         const { props, context } = this;
         const bindings = getBindings(props, context);
         const flux = context[fluxKey];
-        const dispatchProps = _.mapValues(bindings, (route) => async function dispatchAction(query, params) {
-          return await flux.action(route).dispatch(query, params);
+        const dispatchProps = _.mapValues(bindings, (path) => async function dispatchAction(params) {
+          const [action, query] = flux.matchAction(path);
+          return await action.dispatch(query, params);
         });
         if(__DEV__) {
           const inter = _.intersection(Object.keys(dispatchProps), Object.keys(props));

--- a/lib/stores.js
+++ b/lib/stores.js
@@ -65,14 +65,13 @@ function stores(getBindingsNotNormalized, { displayName = void 0, fluxKey = defa
       const { props, context } = this;
       const [, prevBindings] = getBindings(props, context);
       const [flux, nextBindings] = getBindings(nextProps, context);
-      const [removed, added] = diff(nextBindings, (k) => prevBindings[k], deepEqual);
+      const [removed, added] = diff(nextBindings, prevBindings, deepEqual);
       _(removed)
         .keys()
         .each((key) => {
           this.observers.get(key)();
           this.observers.delete(key);
-        })
-      .run();
+        });
       _(added)
         .each((binding, key) => {
           this.updateStoreState(key, flux.readStoreFromState(...binding));
@@ -83,8 +82,7 @@ function stores(getBindingsNotNormalized, { displayName = void 0, fluxKey = defa
               (state) => this.updateStoreState(key, state),
             ),
           );
-        })
-      .run();
+        });
     }
 
     componentWillUnmount() {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0-dev2",
   "description": "Real world apps with React",
   "main": "dist/node/prod/lib/index.js",
-  "browser": "dist/browser/lib/app/index.js",
+  "browser": "dist/browser/prod/lib/index.js",
   "scripts": {
     "test": "gulp test",
     "iron-test": "iron-node node_modules/gulp/bin/gulp.js test"


### PR DESCRIPTION
Fixing `actions `& `stores `client-side:

- Define `observeStore` method in `Flux`
- Change `flux.action(route).dispatch` in `actions` decorator
- Return PENDING `State` in `readFromState` from `Store`
- Check if data exists before unobserve a `Store`
- Change bad parameters when calling `diff` function in `stores` decorator