### PR TITLE
Replace should#eql with should#deepEqual for more clarity

### DIFF
--- a/lib/HTTP/__tests__/app.js
+++ b/lib/HTTP/__tests__/app.js
@@ -18,7 +18,7 @@ describe('@root', () => {
       const flux = createFlux({ port });
       const app = <App flux={flux} />;
       await Nexus.prepare(app);
-      should(ReactDOMServer.renderToStaticMarkup(app)).eql(ReactDOMServer.renderToStaticMarkup(
+      should(ReactDOMServer.renderToStaticMarkup(app)).be.deepEqual(ReactDOMServer.renderToStaticMarkup(
         <div className='App'>
           <ul className='Users'>
             <li>
@@ -46,7 +46,7 @@ describe('@root', () => {
       await flux.dispatchAction('/users/id3/update', { nickname: 'Carol' });
       const app = <App flux={flux} />;
       await Nexus.prepare(app);
-      should(ReactDOMServer.renderToStaticMarkup(app)).eql(ReactDOMServer.renderToStaticMarkup(
+      should(ReactDOMServer.renderToStaticMarkup(app)).be.deepEqual(ReactDOMServer.renderToStaticMarkup(
         <div className='App'>
           <ul className='Users'>
             <li>
@@ -77,7 +77,7 @@ describe('@root', () => {
       const reflux = createFlux().loadState(JSON.parse(json));
       const app = <App flux={reflux} />;
       await Nexus.prepare(app);
-      should(ReactDOMServer.renderToStaticMarkup(app)).eql(ReactDOMServer.renderToStaticMarkup(
+      should(ReactDOMServer.renderToStaticMarkup(app)).be.deepEqual(ReactDOMServer.renderToStaticMarkup(
         <div className='App'>
           <ul className='Users'>
             <li>

--- a/lib/__tests__/app.js
+++ b/lib/__tests__/app.js
@@ -13,7 +13,7 @@ describe('@root', () => {
     const flux = createFlux();
     const app = <App flux={flux} />;
     await Nexus.prepare(app);
-    should(ReactDOMServer.renderToStaticMarkup(app)).eql(ReactDOMServer.renderToStaticMarkup(
+    should(ReactDOMServer.renderToStaticMarkup(app)).be.deepEqual(ReactDOMServer.renderToStaticMarkup(
       <div className='App'>
         <ul className='Users'>
           <li>
@@ -33,7 +33,7 @@ describe('@root', () => {
     await flux.dispatchAction('/users/id3/update', { nickname: 'Carol' });
     const app = <App flux={flux} />;
     await Nexus.prepare(app);
-    should(ReactDOMServer.renderToStaticMarkup(app)).eql(ReactDOMServer.renderToStaticMarkup(
+    should(ReactDOMServer.renderToStaticMarkup(app)).be.deepEqual(ReactDOMServer.renderToStaticMarkup(
       <div className='App'>
         <ul className='Users'>
           <li>
@@ -55,7 +55,7 @@ describe('@root', () => {
     const reflux = createFlux().loadState(JSON.parse(json));
     const app = <App flux={reflux} />;
     await Nexus.prepare(app);
-    should(ReactDOMServer.renderToStaticMarkup(app)).eql(ReactDOMServer.renderToStaticMarkup(
+    should(ReactDOMServer.renderToStaticMarkup(app)).be.deepEqual(ReactDOMServer.renderToStaticMarkup(
       <div className='App'>
         <ul className='Users'>
           <li>

--- a/lib/__tests__/preparable.js
+++ b/lib/__tests__/preparable.js
@@ -45,7 +45,7 @@ describe('preparable', () => {
     class Test extends React.Component {}
     await Test[$prepare]();
     should(spy).have.property('callCount').which.is.exactly(2);
-    should(spy.getCall(0).args).be.eql(['B']);
-    should(spy.getCall(1).args).be.eql(['A']);
+    should(spy.getCall(0).args).be.deepEqual(['B']);
+    should(spy.getCall(1).args).be.deepEqual(['A']);
   });
 });

--- a/lib/__tests__/prepare.js
+++ b/lib/__tests__/prepare.js
@@ -10,7 +10,7 @@ import prepare from '../prepare';
 describe('prepare', () => {
   it('resolves to an identical context on DOM elements', () =>
     prepare(<div />, { bar: 'foo' })
-    .then((context) => should(context).eql({ bar: 'foo' }))
+    .then((context) => should(context).be.deepEqual({ bar: 'foo' }))
   );
   it('prepares a simple element without context side effects', () => {
     const spy = sinon.spy();

--- a/lib/util/__tests__/diff.js
+++ b/lib/util/__tests__/diff.js
@@ -5,17 +5,17 @@ import diff from '../diff';
 
 describe('diff', () => {
   it('returns no-op diff for identical objects', () => {
-    should(diff({}, {})).eql([{}, {}]);
+    should(diff({}, {})).be.deepEqual([{}, {}]);
     should(diff(
       { foo: 'bar' },
       { foo: 'bar' },
-    )).eql([{}, {}]);
+    )).be.deepEqual([{}, {}]);
   });
   it('returns correct diff for different objects', () => {
     should(diff(
       { foo: 'bar', fizz: 'bozz', theta: 'alpha' }, // next
       { foo: 'bar', fizz: 'buzz', beta: 'gamma' }, // prev
-    )).eql([
+    )).be.deepEqual([
       { fizz: 'buzz', beta: 'gamma' }, // removed
       { fizz: 'bozz', theta: 'alpha' }, // added
     ]);


### PR DESCRIPTION
`eql` is not very explicit and can be confusing. `deepEqual` is an [alias](https://github.com/shouldjs/should.js/blob/master/lib/ext/eql.js#L26) to `eql` and is way more comprehensible especially for someone without knowledge about `should`.