### PR TITLE
Remove util/index

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,6 @@ import prepare from './prepare';
 import root from './root';
 import Store from './Store';
 import stores from './stores';
-import util from './util';
 
 export default {
   Action,
@@ -31,5 +30,4 @@ export default {
   root,
   Store,
   stores,
-  util,
 };

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,9 +1,0 @@
-import creatable from './creatable';
-import diff from './diff';
-import isExtensionOf from './isExtensionOf';
-
-export default {
-  creatable,
-  diff,
-  isExtensionOf,
-};


### PR DESCRIPTION
I don't know what is truly intended. I just removed the `lib/util/index.js` which was exporting all `util` features at once (without allowing code optimization).

Maybee should we keep `util/index.js` but also use named exports? Then we could use cleaner imports:
```js
// what is currently done
import isExtensionOf from 'util/isExtensionOf';

// what could be done with named exports into `util/index.js`
import isExtensionOf from 'util';
```

This also removes `util` features from an external usage.