### PR TITLE
Fix gulp lint task

### DIFF
--- a/config/gulp/tasks/lint.js
+++ b/config/gulp/tasks/lint.js
@@ -3,16 +3,18 @@ import gulp from 'gulp';
 import path from 'path';
 import plumber from 'gulp-plumber';
 
-const app = path.join(
+const jsFilesGlob = path.join(
   __dirname, // /config/gulp/tasks
   '..', // /config/gulp
   '..', // /config/
   '..', // /
   'lib', // /lib/
+  '**',
+  '*.js',
 );
 
 export default () =>
-  gulp.task('lint', () => gulp.src(app)
+  gulp.task('lint', () => gulp.src(jsFilesGlob)
     .pipe(plumber())
     .pipe(eslint())
     .pipe(eslint.format())


### PR DESCRIPTION
It didn't work.

`gulp.src` was given a path to the `lib` directory instead of a path glob pattern matching JS files.