### PR TITLE
Polish changes

### DIFF
--- a/Flux.js
+++ b/Flux.js
@@ -1,7 +1,0 @@
-import creatable from './util/creatable';
-
-@creatable
-class Flux {
-}
-
-export default Flux;

--- a/lib/HTTPStore/index.js
+++ b/lib/HTTPStore/index.js
@@ -90,10 +90,14 @@ class HTTPStore extends Store {
    *
    * @private
    * @param {string} path Path to query.
+   * @param {Object} pathQuery Query to be passed to rewrite path.
+   *                 It's there because path is passed directly to avoid to compute it twice when fetch
+   *                 is used internally.
    * @return {State} Result of the request wrapped into {@link State}.
    */
-  async _forceFetch(path, { ignoreCache = false }) {
-    const { pathname, query } = url.parse(path, false, true);
+  async _forceFetch(path, pathQuery) {
+    const { ignoreCache = false, rewritePath } = this.options;
+    const { pathname, query } = url.parse(rewritePath(pathQuery, path), false, true);
     const uri = url.format(Object.assign({}, this.httpConfig, { pathname, query }));
     try {
       const res = await fetch(uri, {
@@ -141,7 +145,7 @@ class HTTPStore extends Store {
    */
   async _fetch(path, query) {
     this._set(path, Store.State.pending({ path }));
-    const state = await this._forceFetch(this.options.rewritePath(query, path), this.options);
+    const state = await this._forceFetch(path, query);
     this._set(path, state);
     return state;
   }
@@ -213,16 +217,6 @@ class HTTPStore extends Store {
    */
   _unobserve(path, observer) {
     this.data.get(path).observers.delete(observer);
-    return this;
-  }
-
-  /**
-   * Updates options
-   * @param  {Object} options Options to merge with the current options.
-   * @return {HTTPStore} Instance of the current HTTPStore.
-   */
-  options(options) {
-    Object.assign(this._options, options);
     return this;
   }
 }


### PR DESCRIPTION
Some modifications regarding #37.

- Without options per query, the `options` is not usefull anymore, so I removed it.
- The path is rewritten directly in the `_forceFetch` method to avoid some bugs (eg: rejected `State` with rewritten path in meta data).
 - The `Flux.js` file at the root of the project has been removed.