### PR TITLE
Resolve preset path from the gulpfile.js file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,8 @@
+const path = require('path');
 require('source-map-support/register');
 require('babel-register')({
   only: ['config'],
-  presets: ['./config/babel/node/dev'],
+  presets: [path.resolve(__dirname, './config/babel/node/dev')],
   retainLines: true,
 });
 require('babel-polyfill');


### PR DESCRIPTION
Without this, babel was not able to resolve the preset path correctly
since a recent update in one of the npm packages.