### PR TITLE
Feature keep value

### DIFF
--- a/lib/HTTPStore/index.js
+++ b/lib/HTTPStore/index.js
@@ -99,6 +99,8 @@ class HTTPStore extends Store {
     const { ignoreCache = false, rewritePath } = this.options;
     const { pathname, query } = url.parse(rewritePath(pathQuery, path), false, true);
     const uri = url.format(Object.assign({}, this.httpConfig, { pathname, query }));
+    const currentState = this._findOrCreatePathData(path).state;
+    this._set(path, Store.State.pending(currentState.value, { path }));
     try {
       const res = await fetch(uri, {
         method: 'GET',
@@ -112,12 +114,12 @@ class HTTPStore extends Store {
       const { status, statusText } = res;
       const meta = { headers, status, statusText };
       if(!res.ok) {
-        return Store.State.reject(await res.text(), meta);
+        throw new Error(await res.text());
       }
-      return Store.State.resolve(await res.json(), meta);
+      return this._set(path, Store.State.resolve(await res.json(), meta));
     }
     catch(err) {
-      return Store.State.reject(err.toString(), { path });
+      return this._set(path, Store.State.reject(currentState.value, err.toString(), { path }));
     }
   }
 
@@ -130,24 +132,7 @@ class HTTPStore extends Store {
    */
   async fetch(query) {
     const path = this.toPath(query);
-    return this._fetch(path, query);
-  }
-
-  /**
-   * Fetchs the state of a store given a path.
-   *
-   * @private
-   * @param {path} path Path that will be use to fetch the store and set the state.
-   * @param {Object} query Query to be passed to rewrite path.
-   *                 It's there because path is passed directly to avoid to compute it twice when fetch
-   *                 is used internally.
-   * @return {State} Fetched state wrapped into {@link State}.
-   */
-  async _fetch(path, query) {
-    this._set(path, Store.State.pending({ path }));
-    const state = await this._forceFetch(path, query);
-    this._set(path, state);
-    return state;
+    return this._forceFetch(path, query);
   }
 
   /**
@@ -160,7 +145,7 @@ class HTTPStore extends Store {
       this.data.set(path, {
         observers: new Set(),
         options: {},
-        state: Store.State.reject(`Path ${path} is not initialized!`, { path }),
+        state: Store.State.reject(null, `Path ${path} is not initialized!`, { path }),
       });
     }
     return this.data.get(path);
@@ -180,7 +165,7 @@ class HTTPStore extends Store {
     const data = this._findOrCreatePathData(path);
     data.state = state;
     data.observers.forEach((onChange) => onChange(state));
-    return this;
+    return state;
   }
 
   /**
@@ -201,7 +186,7 @@ class HTTPStore extends Store {
     const { observers, state } = this._findOrCreatePathData(path);
     observers.add(onChange);
     if(state.isRejected()) {
-      this._fetch(path, query);
+      this._forceFetch(path, query);
     }
     return () => this._unobserve(path, onChange);
   }

--- a/lib/MemoryStore/index.js
+++ b/lib/MemoryStore/index.js
@@ -75,7 +75,7 @@ class MemoryStore extends Store {
   readFromState(query) {
     const path = this.toPath(query);
     if(!this.data.has(path)) {
-      return Store.State.pending({ path });
+      return Store.State.reject(null, `${path} is not set!`, { path });
     }
     return this.data.get(path).state;
   }
@@ -183,7 +183,7 @@ class MemoryStore extends Store {
       throw new Error(`Store not found: ${ path }`);
     }
     const data = this.data.get(path);
-    const state = Store.State.reject('Store deleted', { path });
+    const state = Store.State.reject(data.store.value, 'Store deleted', { path });
     data.observers.forEach((observer) => {
       const [onChange] = observer;
       onChange(state);

--- a/lib/Store.js
+++ b/lib/Store.js
@@ -28,11 +28,12 @@ const REJECTED = 'REJECTED';
 class State {
   /**
    * Creates a new pending State.
+   * @param {*} defaultValue Default value exposed while the state of the store is pending.
    * @param {*} meta Metadata of the State
    * @return {State} The created State
    */
-  static pending(meta) {
-    return this.create({ status: PENDING, meta });
+  static pending(defaultValue, meta) {
+    return this.create({ value: defaultValue, status: PENDING, meta });
   }
 
   /**
@@ -47,12 +48,13 @@ class State {
 
   /**
    * Creates a new rejected State.
+   * @param {*} defaultValue Default value exposed when the store is in a rejected state.
    * @param {String} reason Reason why the State has been rejected
    * @param {*} meta Metadata of the State
    * @return {State} The created State
    */
-  static reject(reason, meta) {
-    return this.create({ status: REJECTED, reason, meta });
+  static reject(defaultValue, reason, meta) {
+    return this.create({ value: defaultValue, status: REJECTED, reason, meta });
   }
 
   /**

--- a/lib/__tests__/node/app.js
+++ b/lib/__tests__/node/app.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-const { describe, it } = global;
+const { describe, it, beforeEach, afterEach } = global;
 import should from 'should/as-function';
 
 import App from '../fixtures/components/App';
@@ -12,9 +12,16 @@ import { prepare } from '../../';
 const API_PORT = 7777;
 
 describe('@root', () => {
+  let apiServer = null;
+
+  beforeEach(() => {
+    apiServer = new ApiServer({ port: API_PORT });
+    return apiServer.startListening();
+  });
+
+  afterEach(() => apiServer.stopListening());
+
   it('prepare App on server', async function test() {
-    const apiServer = new ApiServer({ port: API_PORT });
-    await apiServer.startListening();
     const flux = createFlux({ port: API_PORT });
     const app = <App flux={flux} />;
     await prepare(app);
@@ -60,11 +67,8 @@ describe('@root', () => {
         </div>
       </div>
     ));
-    return await apiServer.stopListening();
   });
   it('dispatches Actions', async function test() {
-    const apiServer = new ApiServer({ port: API_PORT });
-    await apiServer.startListening();
     const flux = createFlux({ port: API_PORT });
     await flux.dispatchAction('/users/1/delete', {});
     await flux.dispatchAction('/users/create', { userName: 'Marcel', rank: 'Bronze' });
@@ -113,11 +117,8 @@ describe('@root', () => {
         </div>
       </div>
     ));
-    return await apiServer.stopListening();
   });
   it('serializes and unserializes state', async function test() {
-    const apiServer = new ApiServer({ port: API_PORT });
-    await apiServer.startListening();
     const flux = createFlux({ port: API_PORT });
     await flux.dispatchAction('/users/1/delete', {});
     await flux.dispatchAction('/users/create', { userName: 'Marcel', rank: 'Bronze' });
@@ -168,6 +169,5 @@ describe('@root', () => {
         </div>
       </div>
     ));
-    return await apiServer.stopListening();
   });
 });

--- a/lib/__tests__/node/stores.js
+++ b/lib/__tests__/node/stores.js
@@ -1,4 +1,4 @@
-const { describe, it } = global;
+const { describe, it, beforeEach, afterEach } = global;
 import should from 'should/as-function';
 
 import ApiServer from '../fixtures/ApiServer';
@@ -10,31 +10,33 @@ const API_PORT = 7777;
 describe('HTTP.Store', () => {
   describe('#options', () => {
     describe('rewritePath', () => {
+      let apiServer = null;
+
+      beforeEach(() => {
+        apiServer = new ApiServer({ port: API_PORT });
+        return apiServer.startListening();
+      });
+
+      afterEach(() => apiServer.stopListening());
+
       it('should correctly access the server with the rewritten path for any path of the store', async function test() {
-        const apiServer = new ApiServer({ port: API_PORT });
-        await apiServer.startListening();
-        try {
-          const store = HTTPStore.create(
-            '/test/users/:userId/custom/path',
-            { protocol: 'http', hostname: 'localhost', port: API_PORT },
-            {
-              rewritePath({ userId }) {
-                return `/users/${userId}`;
-              },
-            }
-          );
+        const store = HTTPStore.create(
+          '/test/users/:userId/custom/path',
+          { protocol: 'http', hostname: 'localhost', port: API_PORT },
+          {
+            rewritePath({ userId }) {
+              return `/users/${userId}`;
+            },
+          }
+        );
 
-          const user1Info = await store.fetch({ userId: '1' });
-          should(user1Info.isResolved()).be.true();
-          should(user1Info.value).be.deepEqual({ userId: 1, userName: 'Martin', rank: 'Gold' });
+        const user1Info = await store.fetch({ userId: '1' });
+        should(user1Info.isResolved()).be.true();
+        should(user1Info.value).be.deepEqual({ userId: 1, userName: 'Martin', rank: 'Gold' });
 
-          const user2Info = await store.fetch({ userId: '2' });
-          should(user2Info.isResolved()).be.true();
-          should(user2Info.value).be.deepEqual({ userId: 2, userName: 'Matthieu', rank: 'Silver' });
-        }
-        finally {
-          return await apiServer.stopListening();
-        }
+        const user2Info = await store.fetch({ userId: '2' });
+        should(user2Info.isResolved()).be.true();
+        should(user2Info.value).be.deepEqual({ userId: 2, userName: 'Matthieu', rank: 'Silver' });
       });
     });
   });


### PR DESCRIPTION
I discussed with @mrtbld and he convinced me that it was maybe a good idea to set the values of `PENDING` and `REJECTED` `State`s to the last one of the store. For `PENDING` it's quite logical actually (because it's a state transiton :wink:). And for `REJECTED` it can be quite handy to be able to display something to the user (if it's relevant) when an error occur.

It's materialized as a default value as first argument when creating `State`s.

I cleaned a bit the "fetch" code for the `HTTPStore` and set  unitialized `MemoryStore`'s path to a `REJECTED` `State` rather than a `PENDING` one.

I realize that the project need more tests because even with some breaking changes, only a few tests were broken.

This PR is obviously open to any discussion. The goal is to make the API of `react-nexus` nicer.