### PR TITLE
Fix broken query string handling

### DIFF
--- a/lib/HTTPStore/index.js
+++ b/lib/HTTPStore/index.js
@@ -97,7 +97,7 @@ class HTTPStore extends Store {
    */
   async _forceFetch(path, pathQuery) {
     const { ignoreCache = false, rewritePath } = this.options;
-    const { pathname, query } = url.parse(rewritePath(pathQuery, path), false, true);
+    const { pathname, query } = url.parse(rewritePath(pathQuery, path), true, true);
     const uri = url.format(Object.assign({}, this.httpConfig, { pathname, query }));
     const currentState = this._findOrCreatePathData(path).state;
     this._set(path, Store.State.pending(currentState.value, { path }));

--- a/lib/__tests__/fixtures/ApiServer.js
+++ b/lib/__tests__/fixtures/ApiServer.js
@@ -63,6 +63,11 @@ class ApiServer {
           this.status = 200;
           yield next;
         })
+        .get('/echoQuery', function* $testQueryString(next) {
+          this.body = this.query;
+          this.status = 200;
+          yield next;
+        })
         .post('/users/create', createBody(), function* $createUser(next) {
           const { userName, rank } = this.request.body;
           users.push({ userId: _.last(users).userId + 1, userName, rank });

--- a/lib/__tests__/node/stores.js
+++ b/lib/__tests__/node/stores.js
@@ -38,6 +38,23 @@ describe('HTTP.Store', () => {
         should(user2Info.isResolved()).be.true();
         should(user2Info.value).be.deepEqual({ userId: 2, userName: 'Matthieu', rank: 'Silver' });
       });
+
+      it('should correctly access the server with the rewritten path with a query', async function test() {
+        const store = HTTPStore.create(
+          '/foo/:foo/bar/:bar',
+          { protocol: 'http', hostname: 'localhost', port: API_PORT },
+          {
+            rewritePath({ foo, bar }) {
+              return `/echoQuery?foo=${foo}&bar=${bar}`;
+            },
+          }
+        );
+
+        const query = { foo: 'baz', bar: 'qux' };
+        const echo = await store.fetch(query);
+        should(echo.isResolved()).be.true();
+        should(echo.value).be.deepEqual(query);
+      });
     });
   });
 });


### PR DESCRIPTION
The query string was not parsed correctly in `HTTPStore._forceFetch`.

https://nodejs.org/docs/latest/api/url.html#url_url_parse_urlstr_parsequerystring_slashesdenotehost