### PR TITLE
[FIX] Dynamic MemoryStores not initialized

### DIFF
--- a/lib/HTTPStore/index.js
+++ b/lib/HTTPStore/index.js
@@ -73,7 +73,7 @@ class HTTPStore extends Store {
 
   /**
    * Returns the HTTPStore's {@link State} according to the given `queryOrPath`.
-   * If store isn't found, returns a rejected {@link State}.
+   * If store isn't found, returns a rejected uninitialized {@link State}.
    *
    * @public
    * @param {Object} query Query to retrieve the matching State.
@@ -144,8 +144,7 @@ class HTTPStore extends Store {
     if(!this.data.has(path)) {
       this.data.set(path, {
         observers: new Set(),
-        options: {},
-        state: Store.State.reject(null, `Path ${path} is not initialized!`, { path }),
+        state: Store.State.reject(null, `Path ${path} is not initialized!`, { path, uninitialized: true }),
       });
     }
     return this.data.get(path);
@@ -201,7 +200,11 @@ class HTTPStore extends Store {
    * @return {HTTPStore} Instance of the current HTTPStore.
    */
   _unobserve(path, observer) {
-    this.data.get(path).observers.delete(observer);
+    const pathData = this.data.get(path);
+    pathData.observers.delete(observer);
+    if(pathData.observers.size === 0 && pathData.state.meta.uninitialized) {
+      this.data.delete(path);
+    }
     return this;
   }
 }

--- a/lib/HTTPStore/index.js
+++ b/lib/HTTPStore/index.js
@@ -144,7 +144,7 @@ class HTTPStore extends Store {
     if(!this.data.has(path)) {
       this.data.set(path, {
         observers: new Set(),
-        state: Store.State.reject(null, `Path ${path} is not initialized!`, { path, uninitialized: true }),
+        state: Store.State.reject(void 0, `Path ${path} is not initialized!`, { path, uninitialized: true }),
       });
     }
     return this.data.get(path);

--- a/lib/MemoryStore/index.js
+++ b/lib/MemoryStore/index.js
@@ -98,7 +98,7 @@ class MemoryStore extends Store {
     if(!this.data.has(path)) {
       this.data.set(path, {
         observers: new Set(),
-        state: Store.State.reject(null, `Path ${path} is not initialized!`, { path, uninitialized: true }),
+        state: Store.State.reject(void 0, `Path ${path} is not initialized!`, { path, uninitialized: true }),
       });
     }
     return this.data.get(path);

--- a/lib/MemoryStore/index.js
+++ b/lib/MemoryStore/index.js
@@ -66,7 +66,7 @@ class MemoryStore extends Store {
 
   /**
    * Returns the MemoryStore's {@link State} according to the given `queryOrPath`.
-   * If store isn't found, returns a rejected {@link State}.
+   * If store isn't found, returns a rejected uninitialized {@link State}.
    *
    * @public
    * @param {Object} query Query to use to retrieve the matching State.
@@ -74,10 +74,7 @@ class MemoryStore extends Store {
    */
   readFromState(query) {
     const path = this.toPath(query);
-    if(!this.data.has(path)) {
-      return Store.State.reject(null, `${path} is not set!`, { path });
-    }
-    return this.data.get(path).state;
+    return this._findOrCreatePathData(path).state;
   }
 
   /**
@@ -90,6 +87,21 @@ class MemoryStore extends Store {
    */
   async fetch(query) {
     return this.readFromState(query);
+  }
+
+  /**
+   * Finds or create the data of a path.
+   * @param {String} path Path to find.
+   * @return {Object} Path data found or created if not found.
+   */
+  _findOrCreatePathData(path) {
+    if(!this.data.has(path)) {
+      this.data.set(path, {
+        observers: new Set(),
+        state: Store.State.reject(null, `Path ${path} is not initialized!`, { path, uninitialized: true }),
+      });
+    }
+    return this.data.get(path);
   }
 
   /**
@@ -106,12 +118,8 @@ class MemoryStore extends Store {
    */
   observe(query, onChange) {
     const path = this.toPath(query);
+    const { observers } = this._findOrCreatePathData(path);
     const firstTick = setImmediate(() => onChange(this.readFromState(query)));
-    const clearFirstTick = () => clearImmediate(firstTick);
-    if(!this.data.has(path)) {
-      return clearFirstTick;
-    }
-    const { observers } = this.data.get(path);
     const observer = [onChange, firstTick];
     observers.add(observer);
     return () => this._unobserve(path, observer);
@@ -129,7 +137,11 @@ class MemoryStore extends Store {
     const [, firstTick] = observer;
     clearImmediate(firstTick);
     if(this.data.has(path)) {
-      this.data.get(path).observers.delete(observer);
+      const pathData = this.data.get(path);
+      pathData.observers.delete(observer);
+      if(pathData.observers.size === 0 && pathData.state.meta.uninitialized) {
+        this.data.delete(path);
+      }
     }
     return this;
   }
@@ -144,12 +156,7 @@ class MemoryStore extends Store {
    * @return {undefined}
    */
   _set(path, state) {
-    if(!this.data.has(path)) {
-      this.data.set(path, {
-        observers: new Set(),
-      });
-    }
-    const data = this.data.get(path);
+    const data = this._findOrCreatePathData(path);
     data.state = state;
     data.observers.forEach(([onChange]) => onChange(state));
   }

--- a/lib/__tests__/node/stores.js
+++ b/lib/__tests__/node/stores.js
@@ -1,9 +1,10 @@
 const { describe, it, beforeEach, afterEach } = global;
 import should from 'should/as-function';
+import sinon from 'sinon';
 
 import ApiServer from '../fixtures/ApiServer';
 
-import { HTTPStore } from '../../';
+import { HTTPStore, MemoryStore } from '../../';
 
 const API_PORT = 7777;
 
@@ -55,6 +56,19 @@ describe('HTTP.Store', () => {
         should(echo.isResolved()).be.true();
         should(echo.value).be.deepEqual(query);
       });
+    });
+  });
+});
+
+describe('Memory.Store', () => {
+  describe('#observe', () => {
+    const onChange = sinon.stub().returns();
+    it('should initializes and observe memory store correctly', () => {
+      const store = MemoryStore.create('/foo/:bar');
+      store.observe({ bar: 'bar' }, onChange);
+      store.set({ bar: 'bar' }, 'foo');
+
+      sinon.assert.called(onChange);
     });
   });
 });


### PR DESCRIPTION
Rework initialized stores in order to create path data for a store if it doesn't exists with a rejected state.