### PR TITLE
Fix a bug on headersToObject function

### DIFF
--- a/lib/HTTPStore/headersToObject.js
+++ b/lib/HTTPStore/headersToObject.js
@@ -8,9 +8,6 @@ import entriesToObject from '../util/entriesToObject';
  * @return {Object} The extracted headers
  */
 function headersToObject(headers) {
-  if(typeof headers.entries === 'function') {
-    return entriesToObject(headers.entries());
-  }
   if(typeof headers.raw === 'function') {
     return headers.raw();
   }


### PR DESCRIPTION
Remove use of for of since transpiled version doesn't work properly on
IE11 and safari iOS8.

Fixed with @Flow11 and @antca .