### PR TITLE
[Perf] Use plugin to cherry-pick only needed lodash modules

### DIFF
--- a/config/babel/browser/dev/index.js
+++ b/config/babel/browser/dev/index.js
@@ -48,5 +48,6 @@ module.exports = {
     'babel-plugin-transform-es2015-typeof-symbol',
     'babel-plugin-transform-es2015-unicode-regex',
     'babel-plugin-transform-es2015-modules-commonjs',
+    'babel-plugin-lodash',
   ],
 };

--- a/config/babel/browser/prod/index.js
+++ b/config/babel/browser/prod/index.js
@@ -50,5 +50,6 @@ module.exports = {
     'babel-plugin-transform-es2015-typeof-symbol',
     'babel-plugin-transform-es2015-unicode-regex',
     ['babel-plugin-transform-es2015-modules-commonjs', { loose: true }],
+    'babel-plugin-lodash',
   ],
 };

--- a/lib/Flux.js
+++ b/lib/Flux.js
@@ -14,19 +14,24 @@ import creatable from './util/creatable';
  * @return {Function} Matcher function
  * @example
  *
- * const userMatcher = createMatcher('/users/:userId');
+ * const userMatcher = createMatcher(pathToRegexp('/users/:userId', []));
  * userMatcher('/users/4') // => { userId: '4' }
  * userMatcher('/test/42') // => null
  */
 function createMatcher({ keys, re }) {
-  function matchPath(path) {
+  return function matchPath(path) {
     const m = re.exec(path);
-    return m === null ? null : _(keys)
-      .map(({ name }, i) => [name, m[i + 1]])
-      .fromPairs()
-    .value();
-  }
-  return matchPath;
+    if(m === null) {
+      return null;
+    }
+
+    // Creates an object with each key/value matching with route path.
+    // Example:
+    // path: `/:foo/:bar` - `route: /test/route`
+    // Created object: `{ foo: 'test', bar: 'route' };`
+    const mapMatchingKeys = _.map(keys, ({ name }, i) => [name, m[i + 1]]);
+    return _.fromPairs(mapMatchingKeys);
+  };
 }
 
 /**
@@ -71,9 +76,8 @@ class StoreNotFoundError extends Error {
  *                                  one of the {@link Routable} matcher, null otherwise.
  */
 function findInMatchers(path, collection) {
-  return _(collection)
-    .map(([matcher, routable]) => [routable, matcher(path)])
-  .find(([, query]) => query !== null);
+  const mapMatchers = _.map(collection, ([matcher, routable]) => [routable, matcher(path)]);
+  return _.find(mapMatchers, ([, matchPath]) => matchPath !== null);
 }
 
 /**
@@ -133,10 +137,9 @@ class Flux {
    * @return {Action} First Action matching the route
    */
   findAction(routeToFind) {
-    return _(this.actions)
-      .filter(([, { route }]) => route === routeToFind)
-      .map(([, action]) => action)
-    .first();
+    const filteredActions = _.filter(this.actions, ([, { route }]) => route === routeToFind);
+    const mapActions = _.map(filteredActions, ([, action]) => action);
+    return _.first(mapActions);
   }
 
   /**
@@ -192,14 +195,13 @@ class Flux {
 
   /**
    * Find a store given a route.
-   * @param {String} routeTofind Route of the store to find
+   * @param {String} routeToFind Route of the store to find
    * @return {Store} First Store matching the route
    */
-  findStore(routeTofind) {
-    return _(this.stores)
-      .filter(([, { route }]) => route === routeTofind)
-      .map(([, store]) => store)
-    .first();
+  findStore(routeToFind) {
+    const filteredStores = _.filter(this.stores, ([, { route }]) => route === routeToFind);
+    const mapStores = _.map(filteredStores, ([, store]) => store);
+    return _.first(mapStores);
   }
 
   /**

--- a/lib/HTTPStore/index.js
+++ b/lib/HTTPStore/index.js
@@ -23,17 +23,18 @@ class HTTPStore extends Store {
    * @param {Object} options Store options object.
    */
   constructor(route, httpConfig, options = {}) {
-    const superArgs = _([
+    const keys = [
       'dumpState',
       'fetch',
       'loadState',
       'observe',
       'readFromState',
-    ])
-      .map((key) => [key, ((...args) => Reflect.apply(HTTPStore.prototype[key], this, args))])
-      .fromPairs()
-    .value();
-    super(route, superArgs);
+    ];
+    const mapHTTPStoreKeys = _.map(
+      keys,
+      (key) => [key, ((...args) => Reflect.apply(HTTPStore.prototype[key], this, args))]
+    );
+    super(route, _.fromPairs(mapHTTPStoreKeys));
     this.httpConfig = httpConfig;
     this.data = new Map();
     this.options = Object.assign({ rewritePath: (query, path) => path }, options);
@@ -48,13 +49,12 @@ class HTTPStore extends Store {
    * @return {HTTPStore} Instance of the current HTTPStore.
    */
   loadState(state) {
-    _(entriesToObject(this.data.entries()))
-      .keys()
-      .each((path) => {
-        if(!state.hasOwnProperty(path)) {
-          this.delete(path);
-        }
-      });
+    const entriesKeys = _.keys(entriesToObject(this.data.entries()));
+    _.each(entriesKeys, (path) => {
+      if(!state.hasOwnProperty(path)) {
+        this.delete(path);
+      }
+    });
     _.each(state, (dump, path) => this._set(path, Store.State.create(dump)));
     return this;
   }
@@ -66,9 +66,7 @@ class HTTPStore extends Store {
    * @return {Array} Serializable array that represent data of the HTTPStore.
    */
   dumpState() {
-    return _(entriesToObject(this.data.entries()))
-      .mapValues(({ state }) => state.dump())
-    .value();
+    return _.mapValues(entriesToObject(this.data.entries()), ({ state }) => state.dump());
   }
 
   /**

--- a/lib/MemoryStore/index.js
+++ b/lib/MemoryStore/index.js
@@ -18,17 +18,18 @@ class MemoryStore extends Store {
    * @param {String} route Route of the MemoryStore
    */
   constructor(route) {
-    const superArgs = _([
+    const keys = [
       'dumpState',
       'fetch',
       'loadState',
       'observe',
       'readFromState',
-    ])
-      .map((key) => [key, ((...args) => Reflect.apply(MemoryStore.prototype[key], this, args))])
-      .fromPairs()
-    .value();
-    super(route, superArgs);
+    ];
+    const mapMemoryStoreKeys = _.map(
+      keys,
+      (key) => [key, ((...args) => Reflect.apply(MemoryStore.prototype[key], this, args))]
+    );
+    super(route, _.fromPairs(mapMemoryStoreKeys));
     this.data = new Map();
   }
 
@@ -41,13 +42,12 @@ class MemoryStore extends Store {
    * @return {MemoryStore} Instance of the current MemoryStore.
    */
   loadState(state) {
-    _(entriesToObject(this.data.entries()))
-      .keys()
-      .each((path) => {
-        if(!state.hasOwnProperty(path)) {
-          this._delete(path);
-        }
-      });
+    const entriesKeys = _.keys(entriesToObject(this.data.entries()));
+    _.each(entriesKeys, (path) => {
+      if(!state.hasOwnProperty(path)) {
+        this._delete(path);
+      }
+    });
     _.each(state, (dump, path) => this._set(path, Store.State.create(dump)));
     return this;
   }
@@ -59,9 +59,7 @@ class MemoryStore extends Store {
    * @return {Array} Serializable array that represent data of the MemoryStore.
    */
   dumpState() {
-    return _(entriesToObject(this.data.entries()))
-      .mapValues(({ state }) => state.dump())
-    .value();
+    return _.mapValues(entriesToObject(this.data.entries()), ({ state }) => state.dump());
   }
 
   /**

--- a/lib/__tests__/browser/createUser.js
+++ b/lib/__tests__/browser/createUser.js
@@ -9,7 +9,7 @@ const { load } = cheerio;
 const TIME_OUT = 250;
 
 function removeReactAttributes(html) {
-  return html.replace(/ (data-reactid|data-react-checksum)=".*?"/g, '');
+  return html.replace(/ (data-reactid|data-react-checksum|data-reactroot)=".*?"/g, '');
 }
 
 const { after, before, describe, it, browser } = global;

--- a/lib/__tests__/browser/deleteUser.js
+++ b/lib/__tests__/browser/deleteUser.js
@@ -9,7 +9,7 @@ const { load } = cheerio;
 const TIME_OUT = 250;
 
 function removeReactAttributes(html) {
-  return html.replace(/ (data-reactid|data-react-checksum)=".*?"/g, '');
+  return html.replace(/ (data-reactid|data-react-checksum|data-reactroot)=".*?"/g, '');
 }
 
 const { after, before, describe, it, browser } = global;

--- a/lib/__tests__/browser/renderedPage.js
+++ b/lib/__tests__/browser/renderedPage.js
@@ -8,7 +8,7 @@ import startServersAndBrowse from '../fixtures/startServersAndBrowse';
 const { load } = cheerio;
 
 function removeReactAttributes(html) {
-  return html.replace(/ (data-reactid|data-react-checksum)=".*?"/g, '');
+  return html.replace(/ (data-reactid|data-react-checksum|data-reactroot)=".*?"/g, '');
 }
 
 const { after, before, describe, it, browser } = global;

--- a/lib/__tests__/browser/updateUser.js
+++ b/lib/__tests__/browser/updateUser.js
@@ -9,7 +9,7 @@ const { load } = cheerio;
 const TIME_OUT = 250;
 
 function removeReactAttributes(html) {
-  return html.replace(/ (data-reactid|data-react-checksum)=".*?"/g, '');
+  return html.replace(/ (data-reactid|data-react-checksum|data-reactroot)=".*?"/g, '');
 }
 
 const { after, before, describe, it, browser } = global;

--- a/lib/__tests__/browser/usersVisibility.js
+++ b/lib/__tests__/browser/usersVisibility.js
@@ -9,7 +9,7 @@ const { load } = cheerio;
 const TIME_OUT = 250;
 
 function removeReactAttributes(html) {
-  return html.replace(/ (data-reactid|data-react-checksum)=".*?"/g, '');
+  return html.replace(/ (data-reactid|data-react-checksum|data-reactroot)=".*?"/g, '');
 }
 
 const { after, before, describe, it, browser } = global;

--- a/lib/stores.js
+++ b/lib/stores.js
@@ -93,23 +93,21 @@ function stores(
       const prevBindings = getBindings(props, flux);
       const nextBindings = getBindings(nextProps, flux);
       const [removed, added] = diff(nextBindings, prevBindings, deepEqual);
-      _(removed)
-        .keys()
-        .each((key) => {
-          this.observers.get(key)();
-          this.observers.delete(key);
-        });
-      _(added)
-        .each((binding, key) => {
-          this.updateStoreState(key, flux.readStoreFromState(binding));
-          this.observers.set(
-            key,
-            flux.observeStore(
-              binding,
-              (state) => this.updateStoreState(key, state),
-            ),
-          );
-        });
+      const removedKeys = _.keys(removed);
+      _.each(removedKeys, (key) => {
+        this.observers.get(key)();
+        this.observers.delete(key);
+      });
+      _.each(added, (binding, key) => {
+        this.updateStoreState(key, flux.readStoreFromState(binding));
+        this.observers.set(
+          key,
+          flux.observeStore(
+            binding,
+            (state) => this.updateStoreState(key, state),
+          ),
+        );
+      });
     }
 
     /**

--- a/lib/util/diff.js
+++ b/lib/util/diff.js
@@ -8,11 +8,7 @@ import _ from 'lodash';
  * @return {Object} Object composed of `prev` properties which are different form the `next` ones.
  */
 function changedProperties(prev, next, eql) {
-  return _(prev)
-    .toPairs()
-    .filter(([k, v]) => !next.hasOwnProperty(k) || !eql(next[k], v))
-    .fromPairs()
-  .value();
+  return _.pickBy(prev, (v, k) => !next.hasOwnProperty(k) || !eql(next[k], v));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "babel-eslint": "^5.0.0-beta6",
     "babel-loader": "^6.2.1",
+    "babel-plugin-lodash": "^3.2.8",
     "babel-plugin-react-display-name": "^2.0.0",
     "babel-plugin-syntax-async-functions": "^6.3.13",
     "babel-plugin-syntax-async-generators": "^6.3.13",


### PR DESCRIPTION
Use babel lodash plugin (@see https://github.com/lodash/babel-plugin-lodash) in order to cherry-pick only needed lodash modules in order to create a smaller lodash builds.

All uses of lodash chaining have been removed: @see https://medium.com/making-internets/why-using-chain-is-a-mistake-9bc1f80d51ba#.r01g1piac

Thanks to this, we can get a build-time performance increase and a bundle size decrease.