### PR TITLE
Make prepare produce a simplified react elements tree for renderToString

### DIFF
--- a/lib/__tests__/node/prepare.js
+++ b/lib/__tests__/node/prepare.js
@@ -4,6 +4,7 @@ import HTTPStatus from 'http-status-codes';
 import _ from 'lodash';
 import nock from 'nock';
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import should from 'should/as-function';
 import sinon from 'sinon';
 import url from 'url';
@@ -16,10 +17,11 @@ import stores from '../../stores';
 import root from '../../root';
 
 describe('prepare', () => {
-  it('resolves to an identical context on DOM elements', () =>
-    prepare(<div />, { bar: 'foo' })
-    .then((context) => should(context).be.deepEqual({ bar: 'foo' }))
-  );
+  it('resolves to an identical context on DOM elements', () => {
+    const context = { bar: 'foo' };
+    return prepare(<div />, context)
+    .then(() => should(context).be.deepEqual({ bar: 'foo' }));
+  });
   it('prepares a simple element without context side effects', () => {
     const spy = sinon.spy();
     @preparable(() => Promise.resolve(spy()))
@@ -41,8 +43,9 @@ describe('prepare', () => {
         return this.context.bar;
       }
     }
-    return prepare(<Test bar='foo' />, {})
-    .then((context) => should(context).have.property('bar').which.is.exactly('foo'));
+    const context = {};
+    return prepare(<Test bar='foo' />, context)
+    .then(() => should(context).have.property('bar').which.is.exactly('foo'));
   });
   it('prepares nested elements', () => {
     const spy = sinon.spy();
@@ -141,5 +144,126 @@ describe('prepare', () => {
     // If store is rejected here, that means nock has thrown an error because it
     // received a second request it didn't expect.
     should(storeState.isRejected()).be.exactly(false, storeState.reason);
+  });
+
+  describe('preparedApp', () => {
+    it('is rendered as the original app', () => {
+      function Foo() {
+        return <span>{'Foo'}</span>;
+      }
+      const app = <Foo />;
+      return prepare(app)
+      .then((preparedApp) => {
+        const appHtml = ReactDOMServer.renderToString(app);
+        const preparedAppHtml = ReactDOMServer.renderToString(preparedApp);
+        should(preparedAppHtml).be.exactly(appHtml);
+      });
+    });
+    it('is rendered as the original app with nested elements', () => {
+      function Bar() {
+        return <span>{'Bar'}</span>;
+      }
+      function Foo() {
+        return <Bar />;
+      }
+      const app = <Foo />;
+      return prepare(app)
+      .then((preparedApp) => {
+        const appHtml = ReactDOMServer.renderToString(app);
+        const preparedAppHtml = ReactDOMServer.renderToString(preparedApp);
+        should(preparedAppHtml).be.exactly(appHtml);
+      });
+    });
+    it('is rendered as the original app with null children', () => {
+      function Bar() {
+        return null;
+      }
+      function Foo() {
+        return (
+          <div>
+            {'Foo'}
+            <Bar />
+          </div>
+        );
+      }
+      const app = <Foo />;
+      return prepare(app)
+      .then((preparedApp) => {
+        const appHtml = ReactDOMServer.renderToString(app);
+        const preparedAppHtml = ReactDOMServer.renderToString(preparedApp);
+        should(preparedAppHtml).be.exactly(appHtml);
+      });
+    });
+    it('is rendered as the original app with false children', () => {
+      function Bar() {
+        return false;
+      }
+      function Foo() {
+        return (
+          <div>
+            {'Foo'}
+            <Bar />
+          </div>
+        );
+      }
+      const app = <Foo />;
+      return prepare(app)
+      .then((preparedApp) => {
+        const appHtml = ReactDOMServer.renderToString(app);
+        const preparedAppHtml = ReactDOMServer.renderToString(preparedApp);
+        should(preparedAppHtml).be.exactly(appHtml);
+      });
+    });
+    it('is rendered as the original app with special elements', () => {
+      function Foo() {
+        return (
+          <div>
+            {'Foo'}
+            <input />
+          </div>
+        );
+      }
+      const app = <Foo />;
+      return prepare(app)
+      .then((preparedApp) => {
+        const appHtml = ReactDOMServer.renderToString(app);
+        const preparedAppHtml = ReactDOMServer.renderToString(preparedApp);
+        should(preparedAppHtml).be.exactly(appHtml);
+      });
+    });
+    it('is rendered as the original app with empty native elements', () => {
+      function Foo() {
+        return (
+          <div>
+            {'Foo'}
+            <div></div>
+          </div>
+        );
+      }
+      const app = <Foo />;
+      return prepare(app)
+      .then((preparedApp) => {
+        const appHtml = ReactDOMServer.renderToString(app);
+        const preparedAppHtml = ReactDOMServer.renderToString(preparedApp);
+        should(preparedAppHtml).be.exactly(appHtml);
+      });
+    });
+    it('is rendered as the original app with native elements which has null as child', () => {
+      function Foo() {
+        return (
+          <div>
+            {'Foo'}
+            <div>{null}</div>
+          </div>
+        );
+      }
+      const app = <Foo />;
+      return prepare(app)
+      .then((preparedApp) => {
+        const appHtml = ReactDOMServer.renderToString(app);
+        const preparedAppHtml = ReactDOMServer.renderToString(preparedApp);
+        should(preparedAppHtml).be.exactly(appHtml);
+      });
+    });
   });
 });

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -1,9 +1,12 @@
 import Promise from 'bluebird';
 import React from 'react';
+import _ from 'lodash';
 
 import isExtensionOf from './util/isExtensionOf';
 import preparable from './preparable';
 const { $prepare } = preparable;
+
+const NULL_CHILD_REACT_ELEMENT = React.createElement(() => null);
 
 /**
  * Create a new `React.Component` instance on which {render} can then be called.
@@ -104,12 +107,40 @@ async function prepareElement(element, context) {
  * additional data.
  * @param {React.Element} element Element whose rendering will be prepared
  * @param {Object} context = {} Context in which to render/apply side effects
- * @return {Promise} Promise for the (possibly altered) context of the rendered tree
+ * @return {Promise} Promise for a prepared react elements tree which will produce
+ * the same output as the original tree when rendered as html by renderToString, but much faster.
  */
 async function prepare(element, context = {}) {
+  // When prepare is called with an array of elements, pass them through prepare to manage them individually.
+  if(Array.isArray(element)) {
+    return Promise.map(element, (children) => prepare(children, context));
+  }
+  // If the element is null or a primitive value, nothing special to do.
+  if(element === null || typeof element !== 'object') {
+    return element;
+  }
+  // Satisfy and then get the childrens of the element.
   const [children, childContext] = await prepareElement(element, context);
-  await Promise.map(React.Children.toArray(children), (child) => prepare(child, childContext));
-  return context;
+  // Recursively prepare the children.
+  const preparedChildren = await prepare(children, childContext);
+  // When the element is native,
+  if(typeof element.type === 'string') {
+    // prepare the new elements props, without the original element's children,
+    const filteredProps = _.omit(element.props, 'children');
+    // if the original element has children, add the prepared children to the new props.
+    if(preparedChildren !== null) {
+      Object.assign(filteredProps, { children: preparedChildren });
+    }
+    // Return a new native element, with the new prepared props.
+    return React.createElement(element.type, filteredProps);
+  }
+  // If the element is not native but its child is null or false,
+  // a dummy component element must replace it (for react-empty comment tags).
+  if(preparedChildren === null || preparedChildren === false) {
+    return NULL_CHILD_REACT_ELEMENT;
+  }
+  // For other cases, simply return the prepared children to skip a tree level.
+  return preparedChildren;
 }
 
 export default prepare;


### PR DESCRIPTION
There was an issue with react nexus, to prepare the app and satisfy its
dependencies, it was required to walk through the whole elements tree and
call the render functions of each element.
Then, with the stores populated, the app was given to
`React.renderToString` which also needs to walk the whole elements tree
and execute each render function to build the string of html.

With this modification, during the prepare phase, a new element tree is
built using the data gathered through the elements tree walk, but only
with the minimal data required for `React.renderToString` to build the
exact same string of html as the one that would be produced by
processing the original app. This is much faster because there is no
render function to call anymore (except for `react-empty` tags).