### PR TITLE
Manage fetching errors without wrapping them in JS Error

### DIFF
--- a/lib/HTTPStore/index.js
+++ b/lib/HTTPStore/index.js
@@ -99,26 +99,23 @@ class HTTPStore extends Store {
     const uri = url.format(Object.assign({}, this.httpConfig, { pathname, query }));
     const currentState = this._findOrCreatePathData(path).state;
     this._set(path, Store.State.pending(currentState.value, { path }));
-    try {
-      const res = await fetch(uri, {
-        method: 'GET',
-        mode: 'cors',
-        headers: Object.assign({}, {
-          'Accept': 'application/json',
-        }, this.httpConfig.headers),
-        cache: ignoreCache ? 'no-cache' : 'default',
-      });
-      const headers = headersToObject(res.headers);
-      const { status, statusText } = res;
-      const meta = { headers, status, statusText };
-      if(!res.ok) {
-        throw new Error(await res.text());
-      }
-      return this._set(path, Store.State.resolve(await res.json(), meta));
+
+    const res = await fetch(uri, {
+      method: 'GET',
+      mode: 'cors',
+      headers: Object.assign({}, {
+        'Accept': 'application/json',
+      }, this.httpConfig.headers),
+      cache: ignoreCache ? 'no-cache' : 'default',
+    });
+    const headers = headersToObject(res.headers);
+    const { status, statusText } = res;
+    const meta = { headers, status, statusText };
+
+    if(!res.ok) {
+      return this._set(path, Store.State.reject(currentState.value, await res.text(), { path }));
     }
-    catch(err) {
-      return this._set(path, Store.State.reject(currentState.value, err.toString(), { path }));
-    }
+    return this._set(path, Store.State.resolve(await res.json(), meta));
   }
 
   /**


### PR DESCRIPTION
Currently, fetched errors are wrapped in `Error` JS object and catched immediately with a classic `try/catch`.
This behavior prevents to correctly use errors returned by APIs. 
Indeed, some APIs return errors in a JSON type and try to parse them.

This commit updates this behavior using the fetched result as a text value for the rejected reason.
Thus, clients can directly use JSON.parse or any parse function in order to manage their errors.