### PR TITLE
Move prop-types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "koa-router": "^5.3.0",
     "mocha": "^2.3.4",
     "nock": "^8.0.0",
-    "prop-types": "^15.6.0",
     "react": "^15.6.2",
     "react-dom": "^15.6.2",
     "react-test-renderer": "^16.0.0",
@@ -125,6 +124,7 @@
     "lodash": "^4.0.0",
     "path-to-regexp": "^1.2.1",
     "setimmediate": "^1.0.4",
+    "prop-types": "^15.6.0",
     "shallowequal": "^1.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
prop-types is a Dependencies not a devDependencies of react-nexus.