### PR TITLE
Dropped isomorphic-fetch in favor of cross-fetch (React Native compatible).

### DIFF
--- a/lib/HTTPStore/index.js
+++ b/lib/HTTPStore/index.js
@@ -1,6 +1,6 @@
 import 'setimmediate';
 import _ from 'lodash';
-import fetch from 'isomorphic-fetch';
+import fetch from 'cross-fetch';
 import url from 'url';
 
 import Store from '../Store';

--- a/lib/__tests__/fixtures/createFlux.js
+++ b/lib/__tests__/fixtures/createFlux.js
@@ -1,6 +1,6 @@
 import url from 'url';
 
-import fetch from 'isomorphic-fetch';
+import fetch from 'cross-fetch';
 
 import { Flux, MemoryStore, HTTPStore, Action } from '../../';
 

--- a/package.json
+++ b/package.json
@@ -119,12 +119,12 @@
     "babel-polyfill": "^6.3.14",
     "babel-runtime": "^6.3.19",
     "bluebird": "^3.1.1",
+    "cross-fetch": "^1.1.0",
     "deep-equal": "^1.0.1",
-    "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.0.0",
     "path-to-regexp": "^1.2.1",
-    "setimmediate": "^1.0.4",
     "prop-types": "^15.6.0",
+    "setimmediate": "^1.0.4",
     "shallowequal": "^1.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
isomorphic-fetch hasn't been updated for a while, so cross-fetch was created in order to provide a more updated, flexible and [fixed](https://github.com/matthew-andrews/isomorphic-fetch/issues/125) alternative to the community.